### PR TITLE
[fix] CICD 파이프라인 수정

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -71,10 +71,12 @@ jobs:
             echo "CURRENT_PORT=8080" >> $GITHUB_ENV
             echo "STOPPED_PORT=8081" >> $GITHUB_ENV
             echo "TARGET_UPSTREAM=green" >> $GITHUB_ENV
+            echo "TARGET_WEBSOCKET_UPSTREAM=websocket_green" >> $GITHUB_ENV
           else
             echo "CURRENT_PORT=8081" >> $GITHUB_ENV
             echo "STOPPED_PORT=8080" >> $GITHUB_ENV
             echo "TARGET_UPSTREAM=blue" >> $GITHUB_ENV
+            echo "TARGET_WEBSOCKET_UPSTREAM=websocket_blue" >> $GITHUB_ENV
           fi
 
       - name: Docker Compose
@@ -104,7 +106,7 @@ jobs:
           script_stop: true
           script: |
             sudo docker exec -i nginxserver bash -c 'echo "set \$service_url ${{env.TARGET_UPSTREAM}};" > /etc/nginx/conf.d/service-env.inc &&
-            echo "set \$websocket_url ${{env.TARGET_UPSTREAM}};" >> /etc/nginx/conf.d/service-env.inc && nginx -s reload'
+            echo "set \$websocket_url ${{env.TARGET_WEBSOCKET_UPSTREAM}};" >> /etc/nginx/conf.d/service-env.inc && nginx -s reload'
 
       - name: Stop current server
         uses: appleboy/ssh-action@master

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -103,7 +103,8 @@ jobs:
           key: ${{ secrets.EC2_SSH_KEY }}
           script_stop: true
           script: |
-            sudo docker exec -i nginxserver bash -c 'echo "set \$service_url ${{env.TARGET_UPSTREAM}};" > /etc/nginx/conf.d/service-env.inc && echo "set \$websocket_url ${{env.TARGET_UPSTREAM}};" >> /etc/nginx/conf.d/service-env.inc && nginx -s reload'
+            sudo docker exec -i nginxserver bash -c 'echo "set \$service_url ${{env.TARGET_UPSTREAM}};" > /etc/nginx/conf.d/service-env.inc &&
+            echo "set \$websocket_url ${{env.TARGET_UPSTREAM}};" >> /etc/nginx/conf.d/service-env.inc && nginx -s reload'
 
       - name: Stop current server
         uses: appleboy/ssh-action@master

--- a/src/main/java/com/dlidam/configuration/webrtc/ConfigUtil.java
+++ b/src/main/java/com/dlidam/configuration/webrtc/ConfigUtil.java
@@ -19,5 +19,6 @@ public class ConfigUtil {
 
     @Value("${socket.fast-api-endpoint}")
     private String fastApiEndpoint;
+
 }
 


### PR DESCRIPTION
### ✅ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [✅] 기능 추가
- [ ] 기능 테스트
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 👀 반영 브랜치
jemin -> dev

### 💻 변경 사항
1. nginx 설정의 upstream에 websocket 관련 설정 수정: green일 때 9093 포트 추가
2. CICD 파이프라인에서 websocket을 blue, green으로 나누는 로직 추가

### 🙏 테스트 결과
ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.