### PR TITLE
[feat] 즐겨찾기 상태 변환 api 추가

### DIFF
--- a/src/main/java/com/dlidam/authentication/presentation/AuthenticationController.java
+++ b/src/main/java/com/dlidam/authentication/presentation/AuthenticationController.java
@@ -39,8 +39,8 @@ public class AuthenticationController {
         final LoginInformationDto loginInformationDto =
                 authenticationService.login(
                         oauth2Type,
-                        request.accessToken(),
-                        request.deviceToken());
+//                        request.deviceToken(),
+                        request.accessToken());
 
         return ResponseEntity.ok(LoginInformationResponse.from(loginInformationDto));
     }

--- a/src/main/java/com/dlidam/authentication/presentation/dto/request/LoginTokenRequest.java
+++ b/src/main/java/com/dlidam/authentication/presentation/dto/request/LoginTokenRequest.java
@@ -5,7 +5,7 @@ import jakarta.validation.constraints.NotEmpty;
 public record LoginTokenRequest(
 
         @NotEmpty(message = "AccessToken을 입력해주세요.")
-        String accessToken,
-        String deviceToken
+        String accessToken
+//        String deviceToken
 ) {
 }

--- a/src/main/java/com/dlidam/chat/application/ChatRoomService.java
+++ b/src/main/java/com/dlidam/chat/application/ChatRoomService.java
@@ -44,7 +44,6 @@ public class ChatRoomService {
                 .orElseGet(() ->{
                     final ChatRoom newChatRoom = new ChatRoom(sender, receiver);
                     newChatRoom.setSenderConnectTrue();
-
                     return chatRoomRepository.save(newChatRoom);
                 });
 

--- a/src/main/java/com/dlidam/chat/infrastructure/websocket/WebSocketProxy.java
+++ b/src/main/java/com/dlidam/chat/infrastructure/websocket/WebSocketProxy.java
@@ -1,4 +1,4 @@
-package com.dlidam.chat.infrastructure.webrtc;
+package com.dlidam.chat.infrastructure.websocket;
 
 import com.corundumstudio.socketio.HandshakeData;
 import com.corundumstudio.socketio.SocketIOClient;
@@ -156,15 +156,15 @@ public class WebSocketProxy {
                             namespace.getRoomOperations(chatMessageRequestDTO.getChatRoomId().toString())
                                     .sendEvent("audioData", Base64.getEncoder().encodeToString(audioData));
 
-                            log.info("audioData = {}", audioData);
-
-                            log.info("output.raw 파일로 저장");
-                            String rawFilePath = "output.raw";
-                            saveAudioToFile(rawFilePath, audioData);
-
-                            log.info("output.raw를 output.wav로 변환");
-                            String wavFilePath = "output.wav";
-                            convertRawToWav(rawFilePath, wavFilePath, 22050, 1, 2);
+//                            log.info("audioData = {}", audioData);
+//
+//                            log.info("output.raw 파일로 저장");
+//                            String rawFilePath = "output.raw";
+//                            saveAudioToFile(rawFilePath, audioData);
+//
+//                            log.info("output.raw를 output.wav로 변환");
+//                            String wavFilePath = "output.wav";
+//                            convertRawToWav(rawFilePath, wavFilePath, 22050, 1, 2);
 
                             log.info("[WebRTCProxy]-[Socketio] Sent audio data to client: {}", client.getSessionId().toString());
                         };

--- a/src/main/java/com/dlidam/device/application/DeviceTokenService.java
+++ b/src/main/java/com/dlidam/device/application/DeviceTokenService.java
@@ -33,7 +33,6 @@ public class DeviceTokenService {
         if(deviceToken.isDifferentToken(newDeviceToken)){
             deviceToken.updateDeviceToken(newDeviceToken);
         }
-
     }
 
     // DeviceToken 객체 생성 및 저장

--- a/src/main/java/com/dlidam/friend/application/FriendService.java
+++ b/src/main/java/com/dlidam/friend/application/FriendService.java
@@ -4,6 +4,7 @@ import com.dlidam.friend.application.dto.*;
 import com.dlidam.friend.application.exception.FriendNotFoundException;
 import com.dlidam.friend.application.exception.MemberNotFoundException;
 import com.dlidam.friend.domain.FriendList;
+import com.dlidam.friend.domain.FriendType;
 import com.dlidam.friend.domain.repository.FriendListRepository;
 import com.dlidam.friend.presentation.dto.request.FriendIdRequest;
 import com.dlidam.user.domain.User;
@@ -14,6 +15,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.stream.Collectors;
+
+import static com.dlidam.friend.domain.FriendType.*;
 
 @Service
 @Transactional(readOnly = true)
@@ -68,6 +71,26 @@ public class FriendService {
     }
 
     @Transactional
+    public void updateFriend(final FriendOperationDto friendDto) {
+        if(!userRepository.existsById(friendDto.userId())){
+            throw new MemberNotFoundException("지정한 사용자를 찾을 수 없습니다.");
+        }
+        if(!userRepository.existsByCustomId(friendDto.customId())){
+            throw new FriendNotFoundException("요청하는 ID에 대한 사용자를 찾을 수 없습니다.");
+        }
+
+        final FriendList friendList = friendListRepository.findByUserIdAndFriendId(friendDto.userId(), friendDto.customId());
+
+        if(friendList.getFriendType().equals(FRIEND)){
+            friendList.updateFriendStatus(CLOSE_FRIEND);
+        } else {
+            friendList.updateFriendStatus(FRIEND);
+        }
+
+        friendListRepository.save(friendList);
+    }
+
+    @Transactional
     public void deleteFriend(final FriendOperationDto friendDto) {
         if(!userRepository.existsById(friendDto.userId())){
             throw new MemberNotFoundException("지정한 사용자를 찾을 수 없습니다.");
@@ -77,4 +100,6 @@ public class FriendService {
         }
         friendListRepository.deleteByUserIdAndFriendId(friendDto.userId(), friendDto.customId());
     }
+
+
 }

--- a/src/main/java/com/dlidam/friend/domain/FriendList.java
+++ b/src/main/java/com/dlidam/friend/domain/FriendList.java
@@ -41,4 +41,6 @@ public class FriendList extends BaseCreateTimeEntity {
         this.friendType = FRIEND;
     }
 
+    public void updateFriendStatus(final FriendType friendType) { this.friendType = friendType; }
+
 }

--- a/src/main/java/com/dlidam/friend/domain/repository/FriendListRepository.java
+++ b/src/main/java/com/dlidam/friend/domain/repository/FriendListRepository.java
@@ -1,6 +1,7 @@
 package com.dlidam.friend.domain.repository;
 
 import com.dlidam.friend.domain.FriendList;
+import com.dlidam.friend.domain.FriendType;
 import com.dlidam.user.domain.User;
 
 import java.util.List;
@@ -14,5 +15,7 @@ public interface FriendListRepository {
     FriendList save(final FriendList newFriend);
 
     List<FriendList> findAllByUser(final User user);
+
+    FriendList findByUserIdAndFriendId(final Long userId, final String customId);
 
 }

--- a/src/main/java/com/dlidam/friend/infrastructure/persistence/FriendListRepositoryImpl.java
+++ b/src/main/java/com/dlidam/friend/infrastructure/persistence/FriendListRepositoryImpl.java
@@ -33,4 +33,9 @@ public class FriendListRepositoryImpl implements FriendListRepository {
     public List<FriendList> findAllByUser(final User user) {
         return jpaFriendListRepository.findAllByUser(user);
     }
+
+    @Override
+    public FriendList findByUserIdAndFriendId(final Long userId, String customId) {
+        return jpaFriendListRepository.findByUserIdAndFriendId(userId, customId);
+    }
 }

--- a/src/main/java/com/dlidam/friend/infrastructure/persistence/JpaFriendListRepository.java
+++ b/src/main/java/com/dlidam/friend/infrastructure/persistence/JpaFriendListRepository.java
@@ -13,4 +13,6 @@ public interface JpaFriendListRepository extends JpaRepository<FriendList, Long>
     List<FriendList> findAllByUser(final User user);
 
     void deleteByUserIdAndFriendId(final Long userId, final String customId);
+
+    FriendList findByUserIdAndFriendId(final Long userId, final String customId);
 }

--- a/src/main/java/com/dlidam/friend/presentation/FriendController.java
+++ b/src/main/java/com/dlidam/friend/presentation/FriendController.java
@@ -41,10 +41,10 @@ public class FriendController {
     @Operation(summary = "아이디로 친구 추가")
     @PostMapping("/add")
     public ResponseEntity<AddSuccessResponse> addFriend(
-//            @AuthenticateUser final AuthenticationUserInfo userInfo,
+            @AuthenticateUser final AuthenticationUserInfo userInfo,
             @RequestBody @Valid final FriendIdRequest request
     ){
-        AuthenticationUserInfo userInfo = new AuthenticationUserInfo(1L);
+//        AuthenticationUserInfo userInfo = new AuthenticationUserInfo(1L);
         log.info("userId = {}의 친구 추가 요청이 들어왔습니다.", userInfo.userId());
         final AddSuccessDto addSuccessDto = friendService.addFriend(FriendOperationDto.of(request, userInfo.userId()));
         final AddSuccessResponse response = AddSuccessResponse.from(addSuccessDto);
@@ -54,9 +54,9 @@ public class FriendController {
     @Operation(summary = "친구 목록 조회")
     @GetMapping("/all")
     public ResponseEntity<List<FriendResponse>> getFriends(
-//            @AuthenticateUser final AuthenticationUserInfo userInfo
+            @AuthenticateUser final AuthenticationUserInfo userInfo
     ){
-        AuthenticationUserInfo userInfo = new AuthenticationUserInfo(1L);
+//        AuthenticationUserInfo userInfo = new AuthenticationUserInfo(1L);
         log.info("userId = {}의 친구 목록 조회 요청이 들어왔습니다.", userInfo.userId());
         final List<FriendDto> friendDtos = friendService.getFriends(userInfo.userId());
         final List<FriendResponse> response = friendDtos.stream()
@@ -66,7 +66,17 @@ public class FriendController {
         return ResponseEntity.ok(response);
     }
 
-    // todo: 친구 즐겨 찾기에 추가 ( POST: /friend/close )
+    @Operation(summary = "즐겨찾기 친구 상태 변환")
+    @PostMapping("/favorite")
+    public ResponseEntity<Void> updateFavorite(
+            @AuthenticateUser final AuthenticationUserInfo userInfo,
+            @RequestBody @Valid final FriendIdRequest request
+    ){
+//        AuthenticationUserInfo userInfo = new AuthenticationUserInfo(1L);
+        log.info("userId = {}의 친구 즐겨 찾기 상태 변경 요청이 들어왔습니다.", userInfo.userId());
+        friendService.updateFriend(FriendOperationDto.of(request, userInfo.userId()));
+        return ResponseEntity.noContent().build();
+    }
 
     @Operation(summary = "친구 삭제")
     @DeleteMapping("/delete")

--- a/src/main/java/com/dlidam/user/domain/User.java
+++ b/src/main/java/com/dlidam/user/domain/User.java
@@ -45,11 +45,11 @@ public class User extends BaseTimeEntity {
 
     @Builder
     private User(
-//            final String customId,
+            final String customId,
             final String oauthId,
             final Oauth2Type oauth2Type
     ) {
-//        this.customId = customId;
+        this.customId = customId;
         this.oauthInformation = new OauthInformation(oauthId, oauth2Type);
     }
 

--- a/src/main/java/com/dlidam/user/presentation/UserController.java
+++ b/src/main/java/com/dlidam/user/presentation/UserController.java
@@ -64,4 +64,7 @@ public class UserController {
         return ResponseEntity.ok(response);
     }
 
+    // todo: 개인 정보 수정 api
+    // todo: 내 프로필 수정하기 api
+
 }


### PR DESCRIPTION
### ✅ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [✅] 기능 추가
- [ ] 기능 테스트
- [✅] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 👀 반영 브랜치
jemin -> dev

### 💻 변경 사항
1. 즐겨찾기 상태 변환 api 추가
2. 로그인 시에 사용되는 device token 로직 모두 주석 처리

### 🙏 테스트 결과
ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.