### PR TITLE
[feat] 채팅방 나가기 API 추가

### DIFF
--- a/src/main/java/com/dlidam/chat/application/ChatMessageService.java
+++ b/src/main/java/com/dlidam/chat/application/ChatMessageService.java
@@ -1,15 +1,18 @@
 package com.dlidam.chat.application;
 
 
+import com.dlidam.chat.application.exception.ChatRoomNotFoundException;
 import com.dlidam.chat.domain.ChatMessage;
 import com.dlidam.chat.domain.ChatRoom;
 import com.dlidam.chat.domain.repository.ChatMessageRepository;
+import com.dlidam.chat.domain.repository.ChatRoomRepository;
 import com.dlidam.chat.dto.request.ChatMessageRequestDTO;
 import com.dlidam.chat.dto.response.ChatMessageDTO;
 import com.dlidam.chat.dto.response.ChatRoomWithLastMessageResponseDTO;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Comparator;
 import java.util.List;
@@ -17,12 +20,17 @@ import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Slf4j
 public class ChatMessageService {
-    public final ChatRoomService chatRoomService;
-    public final ChatMessageRepository chatMessageRepository;
 
+    private final ChatMessageRepository chatMessageRepository;
+    private final ChatRoomRepository chatRoomRepository;
+
+    @Transactional
     public ChatMessage save(final ChatMessageRequestDTO request, final String senderName) {
-          final ChatRoom chatRoom = chatRoomService.findById(request.getChatRoomId());
+          final ChatRoom chatRoom = chatRoomRepository.findById(request.getChatRoomId())
+                  .orElseThrow(() -> new ChatRoomNotFoundException("요청하는 ID에 해당하는 채팅방을 찾을 수 없습니다."));
 
           final ChatMessage newChatMessage = new ChatMessage(
                   request.getSenderId(),

--- a/src/main/java/com/dlidam/chat/application/ChatRoomService.java
+++ b/src/main/java/com/dlidam/chat/application/ChatRoomService.java
@@ -20,6 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.ArrayList;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -43,7 +44,8 @@ public class ChatRoomService {
         final ChatRoom chatRoom = chatRoomRepository.findBySenderAndReceiver(sender, receiver)
                 .orElseGet(() ->{
                     final ChatRoom newChatRoom = new ChatRoom(sender, receiver);
-                    newChatRoom.setSenderConnectTrue();
+                    newChatRoom.updateSenderConnectStatus(true);
+                    newChatRoom.updateReceiverConnectStatus(true);
                     return chatRoomRepository.save(newChatRoom);
                 });
 
@@ -72,8 +74,6 @@ public class ChatRoomService {
         final ChatRoom chatRoom = chatRoomRepository.findBySenderAndReceiver(sender, receiver)
                 .orElseThrow(() -> new ChatRoomNotFoundException("요청하는 채팅방을 찾을 수 없습니다."));
 
-        chatRoom.setReceiverConnectTrue();
-
         return chatRoomRepository.save(chatRoom);
     }
 
@@ -87,41 +87,29 @@ public class ChatRoomService {
     }
 
     public List<ChatRoomWithLastMessageResponseDTO> getAllChatRooms(final Long userId) {
-
         final User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UserNotFoundException("요청하는 ID에 대한 사용자를 찾을 수 없습니다."));
 
-        final List<ChatRoomWithLastMessageDTO> chatRoomWithLastMessageDTOS =
-                chatRoomRepository.findAllChatRoomByUserIdOrderByLastMessage(user.getId());
+        final List<ChatRoom> chatRooms = chatRoomRepository.findAllChatRoomsByUserId(user.getId());
+
+        final List<ChatRoomWithLastMessageDTO> chatRoomWithLastMessageDTOS = chatRooms.stream()
+                .map(chatRoom -> ChatRoomWithLastMessageDTO.of(
+                        chatRoom, chatMessageRepository.findLastMessageInChatRoom(chatRoom.getId())
+                ))
+                .collect(Collectors.toList());
 
         return chatRoomWithLastMessageDTOS.stream()
                 .map(dto -> ChatRoomWithLastMessageResponseDTO.of(user, dto))
                 .toList();
     }
 
-//    @Transactional
-//    public void setLastChatMessage(List<ChatRoom> chatRoomList) {
-//
-//        for (ChatRoom chatRoom : chatRoomList) {
-//            List<ChatMessage> chatMessageList = chatRoom.getChatMessage();
-//            if (!chatMessageList.isEmpty()) {
-//                ChatMessage lastChatMessage = chatMessageList.get(chatMessageList.size() - 1);
-//                chatRoom.setLastChatMessage(lastChatMessage.getMessage());
-//            }
-//        }
-//    }
-
-    public ChatRoom findById(final Long chatRoomId) {
-        return chatRoomRepository.findById(chatRoomId)
-                .orElseThrow(() -> new ChatRoomNotFoundException("요청하는 ID에 해당하는 채팅방을 찾을 수 없습니다."));
-    }
-
     public ChatRoomResponseDTO getChatMessages(final Long chatRoomId, final Long userId) {
-
         final User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UserNotFoundException("요청하는 ID에 대한 사용자를 찾을 수 없습니다."));
 
-        ChatRoom chatRoom = findById(chatRoomId);
+        final ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId)
+                .orElseThrow(() -> new ChatRoomNotFoundException("요청하는 ID에 해당하는 채팅방을 찾을 수 없습니다."));
+
         if (chatRoom.getSender().equals(user)){
             return getSenderMessages(chatRoom);
         } else if (chatRoom.getReceiver().equals(user)) {
@@ -129,4 +117,26 @@ public class ChatRoomService {
         }
         throw new ChatRoomNotFoundException("해당 채팅방의 내역을 불러올 수 없습니다.");
     }
+
+    @Transactional
+    public void exitChatRoom(final Long userId, final Long chatRoomId) {
+        final User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserNotFoundException("요청하는 ID에 대한 사용자를 찾을 수 없습니다."));
+
+        final ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId)
+                .orElseThrow(() -> new ChatRoomNotFoundException("요청하는 ID에 해당하는 채팅방을 찾을 수 없습니다."));
+
+        log.info("chatRoom Sender Status = {}", chatRoom.getSenderConnect());
+        if(chatRoom.getSender().equals(user)) {
+            chatRoom.updateSenderConnectStatus(false);
+        } else {
+            chatRoom.updateReceiverConnectStatus(false);
+        }
+
+        log.info("chatRoom Sender Status = {}", chatRoom.getSenderConnect());
+        if(!chatRoom.getSenderConnect() && !chatRoom.getReceiverConnect()) {
+            chatRoomRepository.deleteById(chatRoomId);
+        }
+    }
+
 }

--- a/src/main/java/com/dlidam/chat/domain/ChatRoom.java
+++ b/src/main/java/com/dlidam/chat/domain/ChatRoom.java
@@ -34,22 +34,18 @@ public class ChatRoom extends BaseTimeEntity {
     @JoinColumn(name = "receiver_id")
     private User receiver;
 
-    private Boolean senderConnect = false;
+    private Boolean senderConnect;
 
-    private Boolean receiverConnect = false;
+    private Boolean receiverConnect;
 
     public ChatRoom(User sender, User receiver){
         this.sender = sender;
         this.receiver = receiver;
     }
 
+    public void updateSenderConnectStatus(final Boolean status){ this.senderConnect = status; }
 
-    public void setSenderConnectTrue(){ this.senderConnect = true; }
-
-    public void setReceiverConnectTrue(){
-        this.receiverConnect = true;
-    }
-
+    public void updateReceiverConnectStatus(final Boolean status){ this.receiverConnect = status; }
 
     public User calculateChatPartnerOf(final User user) {
         if(sender.equals(user)) return receiver;

--- a/src/main/java/com/dlidam/chat/domain/dto/ChatRoomWithLastMessageDTO.java
+++ b/src/main/java/com/dlidam/chat/domain/dto/ChatRoomWithLastMessageDTO.java
@@ -12,4 +12,7 @@ public class ChatRoomWithLastMessageDTO {
     private ChatRoom chatRoom;
     private ChatMessage chatMessage;
 
+    public static ChatRoomWithLastMessageDTO of(final ChatRoom chatRoom, final ChatMessage chatMessage) {
+        return new ChatRoomWithLastMessageDTO(chatRoom, chatMessage);
+    }
 }

--- a/src/main/java/com/dlidam/chat/domain/repository/ChatMessageRepository.java
+++ b/src/main/java/com/dlidam/chat/domain/repository/ChatMessageRepository.java
@@ -11,4 +11,6 @@ public interface ChatMessageRepository {
     ChatMessage save(ChatMessage chatMessage);
 
     Optional<List<ChatMessage>> findAllByChatRoom(final ChatRoom chatRoom);
+
+    ChatMessage findLastMessageInChatRoom(final Long chatRoomId);
 }

--- a/src/main/java/com/dlidam/chat/domain/repository/ChatRoomRepository.java
+++ b/src/main/java/com/dlidam/chat/domain/repository/ChatRoomRepository.java
@@ -15,7 +15,7 @@ public interface ChatRoomRepository {
 
     Optional<ChatRoom> findBySenderAndReceiver(final User sender, final User receiver);
 
-    List<ChatRoomWithLastMessageDTO> findAllChatRoomByUserIdOrderByLastMessage(final Long userId);
+    List<ChatRoom> findAllChatRoomsByUserId(final Long id);
 
-    // List<ChatRoom> findAllByUser(User user);
+    void deleteById(final Long chatRoomId);
 }

--- a/src/main/java/com/dlidam/chat/dto/response/ChatRoomWithLastMessageResponseDTO.java
+++ b/src/main/java/com/dlidam/chat/dto/response/ChatRoomWithLastMessageResponseDTO.java
@@ -48,4 +48,5 @@ public class ChatRoomWithLastMessageResponseDTO {
                         null
                 );
         }
+
 }

--- a/src/main/java/com/dlidam/chat/infrastructure/persistence/ChatMessageRepositoryImpl.java
+++ b/src/main/java/com/dlidam/chat/infrastructure/persistence/ChatMessageRepositoryImpl.java
@@ -21,4 +21,9 @@ public class ChatMessageRepositoryImpl implements ChatMessageRepository {
     public Optional<List<ChatMessage>> findAllByChatRoom(final ChatRoom chatRoom) {
         return jpaChatMessageRepository.findAllByChatRoom(chatRoom);
     }
+
+    @Override
+    public ChatMessage findLastMessageInChatRoom(final Long chatRoomId) {
+        return jpaChatMessageRepository.findLastMessageInChatRoom(chatRoomId);
+    }
 }

--- a/src/main/java/com/dlidam/chat/infrastructure/persistence/ChatRoomRepositoryImpl.java
+++ b/src/main/java/com/dlidam/chat/infrastructure/persistence/ChatRoomRepositoryImpl.java
@@ -30,10 +30,13 @@ public class ChatRoomRepositoryImpl implements ChatRoomRepository {
     }
 
     @Override
-    public List<ChatRoomWithLastMessageDTO> findAllChatRoomByUserIdOrderByLastMessage(final Long userId) {
-        return jpaChatRoomRepository.findAllChatRoomByUserIdOrderByLastMessage(userId);
+    public List<ChatRoom> findAllChatRoomsByUserId(final Long userId) {
+        return jpaChatRoomRepository.findAllChatRoomsByUserId(userId);
     }
 
-//    @Override
-//    public List<ChatRoom> findAllByUser(User user){return jpaChatRoomRepository.findAllByUser(user);}
+    @Override
+    public void deleteById(Long chatRoomId) {
+        jpaChatRoomRepository.deleteById(chatRoomId);
+    }
+
 }

--- a/src/main/java/com/dlidam/chat/infrastructure/persistence/JpaChatMessageRepository.java
+++ b/src/main/java/com/dlidam/chat/infrastructure/persistence/JpaChatMessageRepository.java
@@ -3,10 +3,19 @@ package com.dlidam.chat.infrastructure.persistence;
 import com.dlidam.chat.domain.ChatMessage;
 import com.dlidam.chat.domain.ChatRoom;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
 
 public interface JpaChatMessageRepository extends JpaRepository<ChatMessage, Long> {
     Optional<List<ChatMessage>> findAllByChatRoom(final ChatRoom chatRoom);
+
+    @Query(
+            "SELECT cm FROM ChatMessage cm " +
+            "WHERE cm.id = (SELECT max(c.id) FROM ChatMessage c " +
+            "WHERE c.chatRoom.id = :chatRoomId)"
+    )
+    ChatMessage findLastMessageInChatRoom(@Param("chatRoomId") final Long chatRoomId);
 }

--- a/src/main/java/com/dlidam/chat/infrastructure/persistence/JpaChatRoomRepository.java
+++ b/src/main/java/com/dlidam/chat/infrastructure/persistence/JpaChatRoomRepository.java
@@ -18,17 +18,10 @@ public interface JpaChatRoomRepository extends JpaRepository<ChatRoom, Long> {
 
     Optional<ChatRoom> findBySenderAndReceiver(final User sender, final User receiver);
 
-    @Query("SELECT new com.dlidam.chat.domain.dto.ChatRoomWithLastMessageDTO( " +
-            "c, " +
-            "cm " +
-            ") " +
-            "FROM ChatRoom c " +
-            "LEFT JOIN c.chatMessage cm " +
-            "ON cm.id = (SELECT MAX(cm2.id) FROM ChatMessage cm2 WHERE cm2.chatRoom.id = c.id) " +
-            "JOIN User u " +
-            "ON (c.sender.id = u.id OR c.receiver.id = u.id) " +
-            "WHERE u.id = :userId " +
-            "ORDER BY cm.createdTime DESC")
-    List<ChatRoomWithLastMessageDTO> findAllChatRoomByUserIdOrderByLastMessage(@Param("userId") final Long userId);
-
+    @Query(
+            "SELECT cr FROM ChatRoom cr " +
+            "WHERE (cr.sender.id = :userId AND cr.senderConnect = true) " +
+            "OR (cr.receiver.id = :userId AND cr.receiverConnect = true)"
+    )
+    List<ChatRoom> findAllChatRoomsByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/dlidam/chat/presentation/ChatRoomController.java
+++ b/src/main/java/com/dlidam/chat/presentation/ChatRoomController.java
@@ -26,9 +26,6 @@ import java.util.List;
 @Slf4j
 public class ChatRoomController {
 
-    @Value("${socket.io.host}")
-    private String host;
-
     private final ChatRoomService chatRoomService;
     private final ChatMessageService chatMessageService;
     private final UserService userService;
@@ -62,7 +59,7 @@ public class ChatRoomController {
     }
 
     @GetMapping
-    @Operation(summary = "사용자 채팅방 목록 조회 API")
+    @Operation(summary = "사용자 채팅방 목록 조회")
     public ResponseEntity<List<ChatRoomWithLastMessageResponseDTO>> getChatRooms(
             @AuthenticateUser final AuthenticationUserInfo userInfo
     ){
@@ -73,7 +70,7 @@ public class ChatRoomController {
     }
 
     @GetMapping("/{chatRoomId}")
-    @Operation(summary = "사용자 채팅방 채팅 내역 조회 API")
+    @Operation(summary = "채팅방 채팅 내역 조회")
     public ResponseEntity<ChatRoomResponseDTO> getChatMessages(
             @AuthenticateUser final AuthenticationUserInfo userInfo,
             @PathVariable("chatRoomId") final Long chatRoomId
@@ -84,12 +81,16 @@ public class ChatRoomController {
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 
-    @GetMapping("/socketIo")
-    @Operation(summary = "socektIO IP갖고 오기")
-    public ResponseEntity<?> getChatMessages(
+    @DeleteMapping("/{chatRoomId}")
+    @Operation(summary = "채팅방 나가기")
+    public ResponseEntity<Void> exitChatRoom(
+            @AuthenticateUser final AuthenticationUserInfo userInfo,
+            @PathVariable("chatRoomId") final Long chatRoomId
     ){
-        return ResponseEntity.status(HttpStatus.OK).body(host);
+//        AuthenticationUserInfo userInfo = new AuthenticationUserInfo(1L);
+        log.info("userId = {}의 채팅방의 채팅방 나가기 요청이 들어왔습니다.", userInfo.userId());
+        chatRoomService.exitChatRoom(userInfo.userId(), chatRoomId);
+        return ResponseEntity.noContent().build();
     }
-
 
 }

--- a/src/main/java/com/dlidam/user/application/UserService.java
+++ b/src/main/java/com/dlidam/user/application/UserService.java
@@ -1,9 +1,6 @@
 package com.dlidam.user.application;
 
-import com.dlidam.user.application.dto.CreateUserDto;
-import com.dlidam.user.application.dto.CustomIdDto;
-import com.dlidam.user.application.dto.CustomIdIsAvailableDto;
-import com.dlidam.user.application.dto.UserInfoDto;
+import com.dlidam.user.application.dto.*;
 import com.dlidam.user.application.exception.UserNotFoundException;
 import com.dlidam.user.domain.User;
 import com.dlidam.user.domain.repository.UserRepository;
@@ -32,9 +29,16 @@ public class UserService {
                 createUserDto.isDisabled(),
                 createUserDto.voiceType()
                 );
-
         userRepository.save(user);
+    }
 
+    @Transactional
+    public void updateProfile(final UpdateProfileDto updateProfileDto) {
+        final User user = userRepository.findById(updateProfileDto.userId())
+                .orElseThrow(() -> new UserNotFoundException("사용자 정보를 찾을 수 없습니다."));
+
+        user.updateProfile(updateProfileDto.name(), updateProfileDto.statusMessage());
+        userRepository.save(user);
     }
 
     public UserInfoDto getMyInfo(final Long userId) {
@@ -52,6 +56,7 @@ public class UserService {
         return userRepository.findByCustomId(senderId)
                 .orElseThrow(() -> new UserNotFoundException("사용자 정보를 찾을 수 없습니다."));
     }
+
 
 
 }

--- a/src/main/java/com/dlidam/user/application/dto/UpdateProfileDto.java
+++ b/src/main/java/com/dlidam/user/application/dto/UpdateProfileDto.java
@@ -1,0 +1,18 @@
+package com.dlidam.user.application.dto;
+
+import com.dlidam.user.presentation.dto.request.UpdateProfileRequest;
+
+public record UpdateProfileDto(
+        Long userId,
+        String name,
+        String statusMessage
+) {
+
+    public static UpdateProfileDto of(final Long userId, final UpdateProfileRequest updateProfileRequest) {
+        return new UpdateProfileDto(
+                userId,
+                updateProfileRequest.name(),
+                updateProfileRequest.statusMessage()
+        );
+    }
+}

--- a/src/main/java/com/dlidam/user/application/dto/UserInfoDto.java
+++ b/src/main/java/com/dlidam/user/application/dto/UserInfoDto.java
@@ -1,14 +1,22 @@
 package com.dlidam.user.application.dto;
 
 import com.dlidam.user.domain.User;
+import com.dlidam.user.domain.VoiceType;
 import com.google.firebase.auth.UserInfo;
 
 public record UserInfoDto(
         String customId,
         String name,
-        boolean isDisabled
+        String phoneNumber,
+        boolean isDisabled,
+        VoiceType voiceType
 ) {
     public static UserInfoDto of(final User user) {
-        return new UserInfoDto(user.getCustomId(), user.getName(), user.isDisabled());
+        return new UserInfoDto(
+                user.getCustomId(),
+                user.getName(),
+                user.getPhoneNumber(),
+                user.isDisabled(),
+                user.getVoiceType());
     }
 }

--- a/src/main/java/com/dlidam/user/domain/User.java
+++ b/src/main/java/com/dlidam/user/domain/User.java
@@ -66,4 +66,11 @@ public class User extends BaseTimeEntity {
         this.voiceType = voiceType;
     }
 
+    public void updateProfile(
+            final String name,
+            final String statusMessage
+    ) {
+        this.name = name;
+        this.statusMessage = statusMessage;
+    }
 }

--- a/src/main/java/com/dlidam/user/presentation/UserController.java
+++ b/src/main/java/com/dlidam/user/presentation/UserController.java
@@ -70,7 +70,6 @@ public class UserController {
         log.info("userId = {}의 사용자 아이디 중복 조회 요청이 들어왔습니다.", userInfo.userId());
         final CustomIdIsAvailableDto customIdIsAvailableDto = userService.validateByCustomId(CustomIdDto.of(customIdRequest));
         final CustomIdIsAvailableResponse response = CustomIdIsAvailableResponse.from(customIdIsAvailableDto);
-
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/com/dlidam/user/presentation/UserController.java
+++ b/src/main/java/com/dlidam/user/presentation/UserController.java
@@ -2,13 +2,11 @@ package com.dlidam.user.presentation;
 
 import com.dlidam.authentication.configuration.AuthenticateUser;
 import com.dlidam.authentication.domain.dto.AuthenticationUserInfo;
-import com.dlidam.user.application.dto.CreateUserDto;
-import com.dlidam.user.application.dto.CustomIdDto;
-import com.dlidam.user.application.dto.CustomIdIsAvailableDto;
-import com.dlidam.user.application.dto.UserInfoDto;
+import com.dlidam.user.application.dto.*;
 import com.dlidam.user.presentation.dto.request.CreateUserRequest;
 import com.dlidam.user.application.UserService;
 import com.dlidam.user.presentation.dto.request.CustomIdRequest;
+import com.dlidam.user.presentation.dto.request.UpdateProfileRequest;
 import com.dlidam.user.presentation.dto.response.CustomIdIsAvailableResponse;
 import com.dlidam.user.presentation.dto.response.UserResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -28,7 +26,7 @@ public class UserController {
 
     @Operation(summary = "회원 정보 추가 기입")
     @PostMapping("/my-info")
-    public ResponseEntity<Void> create(
+    public ResponseEntity<Void> createInfo(
             @AuthenticateUser final AuthenticationUserInfo userInfo,
             @RequestBody @Valid final CreateUserRequest createRequest
     ){
@@ -50,6 +48,18 @@ public class UserController {
         return ResponseEntity.ok(userResponse);
     }
 
+    @Operation(summary = "회원 프로필 수정")
+    @PostMapping("/profile")
+    public ResponseEntity<Void> updateProfile(
+            @AuthenticateUser final AuthenticationUserInfo userInfo,
+            @RequestBody @Valid final UpdateProfileRequest updateProfileRequest
+    ){
+//        AuthenticationUserInfo userInfo = new AuthenticationUserInfo(1L);
+        log.info("userId = {}의 내 프로필 수정 요청이 들어왔습니다.", userInfo.userId());
+        userService.updateProfile(UpdateProfileDto.of(userInfo.userId(), updateProfileRequest));
+        return ResponseEntity.noContent().build();
+    }
+
     @Operation(summary = "사용자 아이디 중복 여부")
     @PostMapping("/validate")
     public ResponseEntity<CustomIdIsAvailableResponse> validateByCustomId(
@@ -63,8 +73,5 @@ public class UserController {
 
         return ResponseEntity.ok(response);
     }
-
-    // todo: 개인 정보 수정 api
-    // todo: 내 프로필 수정하기 api
 
 }

--- a/src/main/java/com/dlidam/user/presentation/dto/request/UpdateProfileRequest.java
+++ b/src/main/java/com/dlidam/user/presentation/dto/request/UpdateProfileRequest.java
@@ -1,0 +1,12 @@
+package com.dlidam.user.presentation.dto.request;
+
+import jakarta.validation.constraints.NotEmpty;
+
+public record UpdateProfileRequest(
+        @NotEmpty(message = "사용자 이름이 입력되지 않았습니다.")
+        String name,
+
+        @NotEmpty(message = "사용자 한 줄 소개 입력되지 않았습니다.")
+        String statusMessage
+) {
+}

--- a/src/main/java/com/dlidam/user/presentation/dto/request/UpdateUserRequest.java
+++ b/src/main/java/com/dlidam/user/presentation/dto/request/UpdateUserRequest.java
@@ -6,10 +6,7 @@ import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 
 @CreateUserRequestValid
-public record CreateUserRequest(
-
-        @NotEmpty(message = "사용자 아이디가 입력되지 않았습니다.")
-        String customId,
+public record UpdateUserRequest(
 
         @NotEmpty(message = "사용자 이름이 입력되지 않았습니다.")
         String name,

--- a/src/main/java/com/dlidam/user/presentation/dto/response/UserResponse.java
+++ b/src/main/java/com/dlidam/user/presentation/dto/response/UserResponse.java
@@ -2,13 +2,21 @@ package com.dlidam.user.presentation.dto.response;
 
 import com.dlidam.user.application.dto.CustomIdDto;
 import com.dlidam.user.application.dto.UserInfoDto;
+import com.dlidam.user.domain.VoiceType;
 
 public record UserResponse(
         String customId,
         String name,
-        boolean isDisabled
+        String phoneNumber,
+        boolean isDisabled,
+        VoiceType voiceType
 ) {
     public static UserResponse from(final UserInfoDto userInfoDto) {
-        return new UserResponse(userInfoDto.customId(), userInfoDto.name(), userInfoDto.isDisabled());
+        return new UserResponse(
+                userInfoDto.customId(),
+                userInfoDto.name(),
+                userInfoDto.phoneNumber(),
+                userInfoDto.isDisabled(),
+                userInfoDto.voiceType());
     }
 }


### PR DESCRIPTION
### ✅ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [✅ ] 기능 추가
- [ ] 기능 테스트
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 👀 반영 브랜치
jemin -> dev

### 💻 변경 사항
1. 채팅방 목록 조회 API 수정: connect가 true인 채팅방만 조회되도록
2. 채팅방 나가기 API 추가

### 🙏 테스트 결과
ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.